### PR TITLE
Fix: Ignore different organization's component

### DIFF
--- a/app/cells/decidim/decidim_awesome/content_blocks/map_cell.rb
+++ b/app/cells/decidim/decidim_awesome/content_blocks/map_cell.rb
@@ -40,11 +40,15 @@ module Decidim
 
         def global_map_components
           @global_map_components ||= Decidim::Component.where(manifest_name: [:meetings, :proposals]).published.filter do |component|
-            case component.manifest.name
-            when :meetings
-              true
-            when :proposals
-              component.settings.geocoding_enabled
+            if component.organization == current_organization
+              case component.manifest.name
+              when :meetings
+                true
+              when :proposals
+                component.settings.geocoding_enabled
+              else
+                false
+              end
             else
               false
             end


### PR DESCRIPTION
global_map_components を取得する際、current_organizationに属していないcomponentは無視するようにします。